### PR TITLE
Here are all the changes we had to make to get it to compile on Linux (Ubuntu 10.10, 11.04 and 11.10), both 32 and 64 -bit. You still need to jump through a few hoops (need ogg and vorbis -dev packages installed despite the fact that they are in the dep. 

### DIFF
--- a/CMake/InstallDependencies.cmake
+++ b/CMake/InstallDependencies.cmake
@@ -1,9 +1,6 @@
 #####################################################
 # Install dependencies 
 #####################################################
-if (NOT APPLE AND NOT WIN32)
-  return()
-endif()
 
 option(CAUDIO_COPY_DEPENDENCIES "Copy dependency libs to the build directory" TRUE)
 

--- a/DependenciesSource/libogg-1.2.2/CMakeLists.txt
+++ b/DependenciesSource/libogg-1.2.2/CMakeLists.txt
@@ -12,11 +12,14 @@ include(libogg_src_files)
 add_library(Ogg STATIC ${file_root})
 target_link_libraries(Ogg)
 
+if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set_target_properties( Ogg PROPERTIES COMPILE_FLAGS -fPIC)
+endif()
+
 if (APPLE AND CAUDIO_IOS_BUILD)
 	set_target_properties(Ogg PROPERTIES XCODE_ATTRIBUTE_GCC_THUMB_SUPPORT "NO")
 	set_target_properties(Ogg PROPERTIES XCODE_ATTRIBUTE_GCC_UNROLL_LOOPS "YES")
 	set_target_properties(Ogg PROPERTIES XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY "iPhone Developer")
-
 endif()
 
 install_all_targets(Ogg)

--- a/DependenciesSource/libvorbis-1.3.2/CMakeLists.txt
+++ b/DependenciesSource/libvorbis-1.3.2/CMakeLists.txt
@@ -11,6 +11,11 @@ include(libvorbis_src_files)
 
 add_library(Vorbis STATIC ${file_root})
 target_link_libraries(Vorbis Ogg)
+
+if(UNIX AND CMAKE_SIZEOF_VOID_P EQUAL 8)
+	set_target_properties( Vorbis PROPERTIES COMPILE_FLAGS -fPIC)
+endif()
+
 add_dependencies(Vorbis Ogg)
 
 if (APPLE AND CAUDIO_IOS_BUILD)

--- a/Examples/Tutorial1_2DSound/CMakeLists.txt
+++ b/Examples/Tutorial1_2DSound/CMakeLists.txt
@@ -9,7 +9,7 @@
 PROJECT(Tutorial1_2DSound)
 
 set (SOURCE_FILES
-	src/Main.cpp
+	src/main.cpp
 )
  
  if(CAUDIO_IOS_BUILD)

--- a/Examples/Tutorial2_3DSound/CMakeLists.txt
+++ b/Examples/Tutorial2_3DSound/CMakeLists.txt
@@ -9,7 +9,7 @@
 PROJECT(Tutorial1_3DSound)
 
 set (SOURCE_FILES
-	src/Main.cpp
+	src/main.cpp
 )
  
  if(CAUDIO_IOS_BUILD)

--- a/Examples/Tutorial3_MemoryPlayback/CMakeLists.txt
+++ b/Examples/Tutorial3_MemoryPlayback/CMakeLists.txt
@@ -10,7 +10,7 @@ PROJECT(Tutorial3_MemoryPlayback)
 
 set (SOURCE_FILES
 	include/bling.h
-	src/Main.cpp
+	src/main.cpp
 )
  
  if(CAUDIO_IOS_BUILD)

--- a/Examples/Tutorial4_AudioCapture/CMakeLists.txt
+++ b/Examples/Tutorial4_AudioCapture/CMakeLists.txt
@@ -9,7 +9,7 @@
 PROJECT(Tutorial4_AudioCapture)
 
 set (SOURCE_FILES
-	src/Main.cpp
+	src/main.cpp
 )
  
  if(CAUDIO_IOS_BUILD)

--- a/Examples/Tutorial5_AudioEffects/CMakeLists.txt
+++ b/Examples/Tutorial5_AudioEffects/CMakeLists.txt
@@ -9,7 +9,7 @@
 PROJECT(Tutorial5_AudioEffects)
 
 set (SOURCE_FILES
-	src/Main.cpp
+	src/main.cpp
 )
  
  if(CAUDIO_IOS_BUILD)

--- a/Examples/Tutorial6_CustomEventHandler/CMakeLists.txt
+++ b/Examples/Tutorial6_CustomEventHandler/CMakeLists.txt
@@ -11,7 +11,7 @@ PROJECT(Tutorial6_CustomEventHandler)
 set (SOURCE_FILES
 	include/cTestHandler.h
 	src/cTestHandler.cpp
-	src/Main.cpp
+	src/main.cpp
 )
  
  if(CAUDIO_IOS_BUILD)

--- a/Examples/Tutorial7_CustomLogReceiver/CMakeLists.txt
+++ b/Examples/Tutorial7_CustomLogReceiver/CMakeLists.txt
@@ -11,7 +11,7 @@ PROJECT(Tutorial7_CustomLogReceiver)
 set (SOURCE_FILES
 	include/cTestLogReceiver.h
 	src/cTestLogReceiver.cpp
-	src/Main.cpp
+	src/main.cpp
 )
  
  if(CAUDIO_IOS_BUILD)

--- a/cAudio/include/cSTLAllocator.h
+++ b/cAudio/include/cSTLAllocator.h
@@ -13,6 +13,7 @@
 #include <list>
 #include <vector>
 #include <string>
+#include <cstddef>
 
 namespace cAudio
 {


### PR DESCRIPTION
Removed line 4-6 in CMake/InstallDependencies.cmake so Linux also get the macros.
Edited DependenciesSource/.../CMakeLists.txt to add -fPIC compiler option on Linux 64bit.
Edited all Examples/.../CMakeLists.txt to rename "Main.cpp" to "main.cpp".
Edited cAudio/include/cSTLAllocator.h to make the inclusion of cstddef.h explicit for gcc 2.6+.

Despite this you still need to copy Dependencies/include/OpenAL/alc.h to /usr/include/AL/alc.h (for Ubuntu or whatever path that is on your system) for it to compile if you are not running the development build of OpenAL.
