### PR TITLE
fix compilation on gcc 4.7

### DIFF
--- a/cAudio/Headers/cEFXFunctions.h
+++ b/cAudio/Headers/cEFXFunctions.h
@@ -47,7 +47,7 @@ namespace cAudio
 	//! EFX Extension function pointers and setup
 	struct cEFXFunctions
 	{
-		cEFXFunctions::cEFXFunctions()
+		cEFXFunctions()
 		{
 			alGenEffects = NULL;
 			alDeleteEffects = NULL;


### PR DESCRIPTION
This change fixes compilation on gcc 4.7 under current Arch Linux.
Otherwise at least the -fpermissive flag would be needed to build.
