### PR TITLE
hi wildicv, i added get-methods for bitrates of all decoders

### DIFF
--- a/cAudio/Headers/cAudioManager.h
+++ b/cAudio/Headers/cAudioManager.h
@@ -77,6 +77,12 @@ namespace cAudio
 		virtual IAudioEffects* getEffects();
 #endif
 
+		//! returns a pointer to the used openal context. useful for sharing/reusing them.
+		ALCcontext* getOpenALContext() const { return Context; }
+
+		//! returns a pointer to the used openal device. useful for sharing/reusing them.
+		ALCdevice* getOpenALDevice() const { return Device;	}
+
 	protected:
 		virtual void run();
 

--- a/cAudio/Headers/cAudioSource.h
+++ b/cAudio/Headers/cAudioSource.h
@@ -41,6 +41,8 @@ namespace cAudio
 #endif
 		~cAudioSource();
 
+		virtual AudioFormats getFormat() const;
+
 		virtual bool play();
 		virtual bool play2d(const bool& toLoop = false);
 		virtual bool play3d(const cVector3& position, const float& soundstr = 1.0 , const bool& toLoop = false);

--- a/cAudio/Headers/cOggDecoder.h
+++ b/cAudio/Headers/cOggDecoder.h
@@ -38,6 +38,9 @@ namespace cAudio
 			virtual int getCurrentPosition();
 			virtual int getCurrentCompressedPosition();
 			virtual cAudioString getType() const;
+			virtual long getBitRateNominal();
+			virtual long getBitRateLower();
+			virtual long getBitRateUpper();
 
         protected:
        	    //! Callbacks used for read memory

--- a/cAudio/Headers/cRawDecoder.h
+++ b/cAudio/Headers/cRawDecoder.h
@@ -30,6 +30,9 @@ namespace cAudio
 			virtual int getCurrentPosition();
 			virtual int getCurrentCompressedPosition();
 			virtual cAudioString getType() const;
+			virtual long getBitRateNominal();
+			virtual long getBitRateLower();
+			virtual long getBitRateUpper();
 
         private:
             unsigned int Frequency;

--- a/cAudio/Headers/cWavDecoder.h
+++ b/cAudio/Headers/cWavDecoder.h
@@ -33,6 +33,9 @@ namespace cAudio
 			virtual int getCurrentPosition();
 			virtual int getCurrentCompressedPosition();
 			virtual cAudioString getType() const;
+			virtual long getBitRateNominal();
+			virtual long getBitRateLower();
+			virtual long getBitRateUpper();
 
         private:
             short Channels;

--- a/cAudio/include/IAudioDecoder.h
+++ b/cAudio/include/IAudioDecoder.h
@@ -74,6 +74,15 @@ namespace cAudio
 			//! Returns the IAudioDecoderType.
 			virtual cAudioString getType() const = 0;
 
+			//! returns the average bitrate of the decoded audio stream.
+			virtual long getBitRateNominal() = 0;
+
+			//! returns the minimum bitrate of the decoded audio stream.
+			virtual long getBitRateLower() = 0;
+
+			//! returns the maximum bitrate of the decoded audio stream.
+			virtual long getBitRateUpper() = 0;
+
 		protected:
 			//! Pointer to the data source to take audio data from.
 			IDataSource* Stream;

--- a/cAudio/include/IAudioSource.h
+++ b/cAudio/include/IAudioSource.h
@@ -21,6 +21,9 @@ namespace cAudio
 		IAudioSource() {}
 		virtual ~IAudioSource() {}
 
+		//! Returns the format of the audio data
+		virtual AudioFormats getFormat() const = 0;
+
 		//! Plays the source with the last set parameters.
 		/**
 		\return True if the source is playing, false if not. */

--- a/cAudio/src/cAudioSource.cpp
+++ b/cAudio/src/cAudioSource.cpp
@@ -99,6 +99,10 @@ namespace cAudio
 		unRegisterAllEventHandlers();
     }
 
+	AudioFormats cAudioSource::getFormat() const
+	{
+		return Decoder->getFormat();
+	}
 
 	bool cAudioSource::drop()
 	{

--- a/cAudio/src/cOggDecoder.cpp
+++ b/cAudio/src/cOggDecoder.cpp
@@ -180,6 +180,22 @@ namespace cAudio
 	{
 		return cAudioString(_CTEXT("cOggDecoder"));
 	}
+
+	long cOggDecoder::getBitRateNominal()
+	{
+		return vorbisInfo->bitrate_nominal;
+	}
+
+	long cOggDecoder::getBitRateLower()
+	{
+		return vorbisInfo->bitrate_lower;
+	}
+
+	long cOggDecoder::getBitRateUpper()
+	{
+		return vorbisInfo->bitrate_upper;
+	}
+
 };
 
 #endif

--- a/cAudio/src/cRawDecoder.cpp
+++ b/cAudio/src/cRawDecoder.cpp
@@ -116,4 +116,25 @@ namespace cAudio{
 	{
 		return cAudioString(_CTEXT("cRawDecoder"));
 	}
+
+	long cRawDecoder::getBitRateNominal()
+	{
+		if(Format == EAF_8BIT_MONO || EAF_8BIT_STEREO)
+			return Frequency * 8;
+		else if(Format == EAF_16BIT_MONO || EAF_16BIT_STEREO)
+			return Frequency * 16;
+
+		return 0;
+	}
+
+	long cRawDecoder::getBitRateLower()
+	{
+		return getBitRateNominal();
+	}
+
+	long cRawDecoder::getBitRateUpper()
+	{
+		return getBitRateNominal();
+	}
+
 }

--- a/cAudio/src/cWavDecoder.cpp
+++ b/cAudio/src/cWavDecoder.cpp
@@ -230,6 +230,22 @@ namespace cAudio
 	{
 		return cAudioString(_CTEXT("cWavDecoder"));
 	}
+
+	long cWavDecoder::getBitRateNominal()
+	{
+		return BitsPerSample * SampleRate;
+	}
+
+	long cWavDecoder::getBitRateLower()
+	{
+		return getBitRateNominal();
+	}
+
+	long cWavDecoder::getBitRateUpper()
+	{
+		return getBitRateNominal();
+	}
+
 };
 
 #endif


### PR DESCRIPTION
i added get-methods for bitrates of all decoders so users can query
average/min/max bitrate of a stream if desired.

somehow it looks like lineendings got mixed up. i use win7, else you would see the few added lines only.

please check if returned bitrates are computed correctly, but i think so.