### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR for modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ project(cAudio)
 
 # Include necessary submodules
 set(CMAKE_MODULE_PATH 
-  "${CMAKE_SOURCE_DIR}/CMake"
-  "${CMAKE_SOURCE_DIR}/CMake/Utils" 
-  "${CMAKE_SOURCE_DIR}/CMake/Packages"
+  "${CMAKE_CURRENT_SOURCE_DIR}/CMake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Utils"
+  "${CMAKE_CURRENT_SOURCE_DIR}/CMake/Packages"
 )
 
 include(CMakeDependentOption)

--- a/cAudio/CMakeLists.txt
+++ b/cAudio/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CAUDIO_STATIC)
 endif()
 
 # generate cAudioBuildSettings.h 
-configure_file(${CMAKE_SOURCE_DIR}/CMake/Templates/cAudioBuildSettings.h.in ${CMAKE_BINARY_DIR}/include/cAudioBuildSettings.h @ONLY)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/../CMake/Templates/cAudioBuildSettings.h.in ${CMAKE_BINARY_DIR}/include/cAudioBuildSettings.h @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/include/cAudioBuildSettings.h DESTINATION include/cAudio)
 INSTALL(DIRECTORY include/ DESTINATION include/cAudio FILES_MATCHING PATTERN "*.h")
 


### PR DESCRIPTION
I'm using cAudio as a submodule and adds it as part of the overall build using add_subdirectory(path_to_caudio). This causes cAudio to look for modules in the wrong place

These commits make it possible to add cAudio from another CMakeLists.txt by using ${CMAKE_CURRENT_SOURCE_DIR} instead when configuring module paths.