### PR TITLE
Added a virtual destructor to device list

### DIFF
--- a/cAudio/include/IAudioDeviceList.h
+++ b/cAudio/include/IAudioDeviceList.h
@@ -17,6 +17,8 @@ namespace cAudio
 	class IAudioDeviceList
 	{
 	public:
+        virtual ~IAudioDeviceList() {};
+        
 		virtual unsigned int getDeviceCount() = 0;
 		virtual cAudioString getDeviceName(unsigned int idx) = 0;
 		virtual cAudioString getDeviceDescription(unsigned int idx) = 0;


### PR DESCRIPTION
This stops gcc from complaining about deleting through non-virtual base class destructor.
Happens with the first example on this line:
```
CAUDIO_DELETE pDeviceList;
```