### PR TITLE
Fix compile error with dlerror() on Android

### DIFF
--- a/cAudio/src/cPluginManager.cpp
+++ b/cAudio/src/cPluginManager.cpp
@@ -186,7 +186,7 @@ namespace cAudio
 		return ret;
 
 #elif defined(CAUDIO_PLATFORM_MAC) || defined(CAUDIO_PLATFORM_LINUX)
-		char* error = dlerror();
+		const char* error = dlerror();
 
 		return error != NULL ? cAudioString(error) : cAudioString("");
 #else


### PR DESCRIPTION
Apparently some dlerror() implementations return the error string as a
const char* in stead of a char* (e.g. Android NDK). Making the variable
storing the returned value a const ensures that it works with any
implementation.

Tested on Linux (GCC) and Android (GCC, API 9, ARM).