### PR TITLE
Remove a duplicated virtual destructor

### DIFF
--- a/cAudio/include/IAudioDeviceList.h
+++ b/cAudio/include/IAudioDeviceList.h
@@ -17,8 +17,6 @@ namespace cAudio
 	class IAudioDeviceList
 	{
 	public:
-        virtual ~IAudioDeviceList() {};
-        
 		virtual unsigned int getDeviceCount() = 0;
 		virtual cAudioString getDeviceName(unsigned int idx) = 0;
 		virtual cAudioString getDeviceDescription(unsigned int idx) = 0;


### PR DESCRIPTION
Seems like this issue was fixed independently by commits
22ff1a97 and 36943a18, and both ended up getting merged,
giving us a redeclaration of the virtual destructor.