### PR TITLE
Dont drop the already dropped source.

### DIFF
--- a/cAudio/src/cAudioManager.cpp
+++ b/cAudio/src/cAudioManager.cpp
@@ -368,8 +368,8 @@ namespace cAudio
 			if(audio != NULL)
 				return audio;
 
-			if(source)
-				source->drop();
+			// if(source)
+			// 	source->drop();
 		}
 		return NULL;
     }

--- a/cAudio/src/cAudioManager.cpp
+++ b/cAudio/src/cAudioManager.cpp
@@ -334,9 +334,6 @@ namespace cAudio
 					if(audio != NULL)
 						return audio;
 
-					//if(source)
-					//	source->drop();
-
 					return NULL;
 				}
 			}
@@ -367,9 +364,6 @@ namespace cAudio
 			IAudioSource* audio = createAudioSource(decoder, audioName, _CTEXT("cMemorySource"));
 			if(audio != NULL)
 				return audio;
-
-			// if(source)
-			// 	source->drop();
 		}
 		return NULL;
     }
@@ -401,9 +395,6 @@ namespace cAudio
 			IAudioSource* audio = createAudioSource(decoder, audioName, _CTEXT("cMemorySource"));
 			if(audio != NULL)
 				return audio;
-
-			if(source)
-				source->drop();
 		}
 		return NULL;
 	}
@@ -438,9 +429,6 @@ namespace cAudio
 
 					if(buffer != NULL)
 						return buffer;
-
-					//if(source)
-					//	source->drop();
 
 					return NULL;
 				}


### PR DESCRIPTION
I chose to do the same thing done in some of the create methods.  Since source is still defined calling drop() again causes a SEGFAULT.