### PR TITLE
Fixed linux compile

### DIFF
--- a/DependenciesSource/libogg-1.2.2/include/ogg/os_types.h
+++ b/DependenciesSource/libogg-1.2.2/include/ogg/os_types.h
@@ -138,6 +138,16 @@
    typedef unsigned int ogg_uint32_t;
    typedef long long int ogg_int64_t;
 
+#elif defined(__linux__)
+
+   /* Linux GCC or clang */
+#    include <stdint.h>
+   typedef int16_t ogg_int16_t;
+   typedef uint16_t ogg_uint16_t;
+   typedef int32_t ogg_int32_t;
+   typedef uint32_t ogg_uint32_t;
+   typedef int64_t ogg_int64_t;
+   typedef uint64_t ogg_uint64_t;
 #else
 
 #  include <ogg/config_types.h>


### PR DESCRIPTION
Trying to compile master on linux gives this error:
`in file included from /home/hhyyrylainen/Projects/Thrive install scripts/cAudio/DependenciesSource/libogg-1.2.2/include/ogg/ogg.h:25:0,
                 from /home/hhyyrylainen/Projects/Thrive install scripts/cAudio/DependenciesSource/libogg-1.2.2/src/framing.c:25:
/home/hhyyrylainen/Projects/Thrive install scripts/cAudio/DependenciesSource/libogg-1.2.2/include/ogg/os_types.h:143:32: vakava virhe: ogg/config_types.h: Tiedostoa tai hakemistoa ei ole
käännös keskeytyi.
DependenciesSource/libogg-1.2.2/CMakeFiles/Ogg.dir/build.make:86: recipe for target 'DependenciesSource/libogg-1.2.2/CMakeFiles/Ogg.dir/src/framing.c.o' failed
make[2]: *** [DependenciesSource/libogg-1.2.2/CMakeFiles/Ogg.dir/src/framing.c.o] Error 1
make[2]: *** Odotetaan keskeneräisiä töitä....
In file included from /home/hhyyrylainen/Projects/Thrive install scripts/cAudio/DependenciesSource/libogg-1.2.2/include/ogg/ogg.h:25:0,
                 from /home/hhyyrylainen/Projects/Thrive install scripts/cAudio/DependenciesSource/libogg-1.2.2/src/bitwise.c:24:
/home/hhyyrylainen/Projects/Thrive install scripts/cAudio/DependenciesSource/libogg-1.2.2/include/ogg/os_types.h:143:32: vakava virhe: ogg/config_types.h: Tiedostoa tai hakemistoa ei ole
käännös keskeytyi.
DependenciesSource/libogg-1.2.2/CMakeFiles/Ogg.dir/build.make:62: recipe for target 'DependenciesSource/libogg-1.2.2/CMakeFiles/Ogg.dir/src/bitwise.c.o' failed
make[2]: *** [DependenciesSource/libogg-1.2.2/CMakeFiles/Ogg.dir/src/bitwise.c.o] Error 1
CMakeFiles/Makefile2:85: recipe for target 'DependenciesSource/libogg-1.2.2/CMakeFiles/Ogg.dir/all' failed
`

This is a fix for that issue.