### PR TITLE
The location of the log file can now be specified

### DIFF
--- a/cAudio/CMakeLists.txt
+++ b/cAudio/CMakeLists.txt
@@ -26,6 +26,9 @@ else()
 	target_link_libraries(cAudio ${OPENAL_LIBRARIES})
 endif()
 
+set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY VERSION "2.3.0")
+set_property(TARGET ${CMAKE_PROJECT_NAME} PROPERTY SOVERSION 2 )
+
 if (APPLE AND CAUDIO_IOS_BUILD)
 	set_target_properties(cAudio PROPERTIES XCODE_ATTRIBUTE_GCC_THUMB_SUPPORT "NO")
 	set_target_properties(cAudio PROPERTIES XCODE_ATTRIBUTE_GCC_UNROLL_LOOPS "YES")

--- a/cAudio/Headers/cFileLogReceiver.h
+++ b/cAudio/Headers/cFileLogReceiver.h
@@ -14,7 +14,7 @@ namespace cAudio
 	class cFileLogReceiver : public ILogReceiver
 	{
 	public:
-		cFileLogReceiver();
+		cFileLogReceiver(const char *lFilePath);
 		~cFileLogReceiver();
 
 		bool OnLogMessage(const char* sender, const char* message, LogLevel level, float time);
@@ -22,7 +22,7 @@ namespace cAudio
 	private:
 
 		bool firsttime;
-
+		const char *logFilePath;
 	};
 };
 #endif

--- a/cAudio/include/cAudio.h
+++ b/cAudio/include/cAudio.h
@@ -108,9 +108,10 @@ namespace cAudio {
 	/** Note: This is the only way to get access to the audio playback capabilities of cAudio.
 	You must delete this interface using destroyAudioManager() once you are done with it.
 	\param initializeDefault: Whether to return an object initialized with the default settings.  If set to false, you must make a call to initialize before you can create audio sources.
+        \param lFilePath Where the log file is going to be placed
 	\return A pointer to the created object, NULL if the object could not be allocated.
 	*/
-	CAUDIO_API IAudioManager* createAudioManager(bool initializeDefault = true);
+        CAUDIO_API IAudioManager* createAudioManager(bool initializeDefault = true, const char *lFilePath = "cAudioEngineLog.html");
 
 	//! Destroys an interface to a previously created Audio Manager and frees the memory allocated for it.
 	/**

--- a/cAudio/src/cAudio.cpp
+++ b/cAudio/src/cAudio.cpp
@@ -77,8 +77,11 @@ namespace cAudio
   CAUDIO_API IAudioManager* createAudioManager(bool initializeDefault, const char *lFilePath)
 	{
 		cAudioManager* manager = CAUDIO_NEW cAudioManager;
+#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
 		if(FileLog == nullptr)
+
          		FileLog = new cFileLogReceiver(lFilePath);
+#endif
 		if(manager)
 		{
 			if(initializeDefault) 

--- a/cAudio/src/cAudio.cpp
+++ b/cAudio/src/cAudio.cpp
@@ -110,6 +110,8 @@ namespace cAudio
 
 	CAUDIO_API void destroyAudioManager(IAudioManager* manager)
 	{
+	  if(FileLog not_eq nullptr)
+         	  delete FileLog;
 		if(manager)
 		{
 #ifdef CAUDIO_COMPILE_WITH_PLUGIN_SUPPORT

--- a/cAudio/src/cAudio.cpp
+++ b/cAudio/src/cAudio.cpp
@@ -113,8 +113,10 @@ namespace cAudio
 
 	CAUDIO_API void destroyAudioManager(IAudioManager* manager)
 	{
+#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
 	  if(FileLog not_eq nullptr)
          	  delete FileLog;
+#endif
 		if(manager)
 		{
 #ifdef CAUDIO_COMPILE_WITH_PLUGIN_SUPPORT

--- a/cAudio/src/cAudio.cpp
+++ b/cAudio/src/cAudio.cpp
@@ -31,6 +31,19 @@ namespace cAudio
 {
 
 	//---------------------------------------------------------------------------------------
+	// Logger section
+	//---------------------------------------------------------------------------------------
+
+#if CAUDIO_COMPILE_WITH_CONSOLE_LOG_RECEIVER == 1
+	static cConsoleLogReceiver ConsoleLog;
+#endif
+
+#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
+  //	static cFileLogReceiver *FileLog = new cFileLogReceiver();
+  static cFileLogReceiver *FileLog;
+#endif
+
+	//---------------------------------------------------------------------------------------
 	// Audio manager section
 	//---------------------------------------------------------------------------------------
 
@@ -46,10 +59,11 @@ namespace cAudio
 #if CAUDIO_COMPILE_WITH_FILE_SOURCE == 1
 	static cFileSourceFactory FileSourceFactory;
 #endif
-
-	CAUDIO_API IAudioManager* createAudioManager(bool initializeDefault)
+  CAUDIO_API IAudioManager* createAudioManager(bool initializeDefault, const char *lFilePath)
 	{
 		cAudioManager* manager = CAUDIO_NEW cAudioManager;
+		if(FileLog == nullptr)
+         		FileLog = new cFileLogReceiver(lFilePath);
 		if(manager)
 		{
 			if(initializeDefault) 
@@ -98,6 +112,26 @@ namespace cAudio
 		}
 	}
 
+  //////////////////////////////////////////
+
+	CAUDIO_API ILogger* getLogger()
+	{
+        static cLogger* Logger = NULL;
+		if(!Logger)
+		{
+			Logger = new cLogger;
+#if CAUDIO_COMPILE_WITH_CONSOLE_LOG_RECEIVER == 1
+			Logger->registerLogReceiver(&ConsoleLog, "Console");
+#endif
+#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
+			Logger->registerLogReceiver(FileLog,"File");
+#endif
+		}
+		return Logger;
+	}
+
+
+
 	//---------------------------------------------------------------------------------------
 	// Audio capture section
 	//---------------------------------------------------------------------------------------
@@ -135,35 +169,6 @@ namespace cAudio
 			CAUDIO_DELETE capture;
 			capture = NULL;
 		}
-	}
-
-	//---------------------------------------------------------------------------------------
-	// Logger section
-	//---------------------------------------------------------------------------------------
-
-#if CAUDIO_COMPILE_WITH_CONSOLE_LOG_RECEIVER == 1
-	static cConsoleLogReceiver ConsoleLog;
-#endif
-
-#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
-	static cFileLogReceiver FileLog;
-#endif
-
-	CAUDIO_API ILogger* getLogger()
-	{
-        static cLogger* Logger = NULL;
-
-		if(!Logger)
-		{
-			Logger = new cLogger;
-#if CAUDIO_COMPILE_WITH_CONSOLE_LOG_RECEIVER == 1
-			Logger->registerLogReceiver(&ConsoleLog, "Console");
-#endif
-#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
-			Logger->registerLogReceiver(&FileLog,"File");
-#endif
-		}
-		return Logger;
 	}
 
 	//---------------------------------------------------------------------------------------

--- a/cAudio/src/cAudio.cpp
+++ b/cAudio/src/cAudio.cpp
@@ -30,22 +30,37 @@
 namespace cAudio
 {
 
-	//---------------------------------------------------------------------------------------
-	// Logger section
-	//---------------------------------------------------------------------------------------
+//---------------------------------------------------------------------------------------
+// Logger section
+//---------------------------------------------------------------------------------------
 
 #if CAUDIO_COMPILE_WITH_CONSOLE_LOG_RECEIVER == 1
 	static cConsoleLogReceiver ConsoleLog;
 #endif
 
 #if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
-  //	static cFileLogReceiver *FileLog = new cFileLogReceiver();
-  static cFileLogReceiver *FileLog;
+        static cFileLogReceiver *FileLog;
 #endif
 
-	//---------------------------------------------------------------------------------------
-	// Audio manager section
-	//---------------------------------------------------------------------------------------
+  CAUDIO_API ILogger* getLogger()
+  {
+    static cLogger* Logger = NULL;
+    if(!Logger)
+      {
+	Logger = new cLogger;
+#if CAUDIO_COMPILE_WITH_CONSOLE_LOG_RECEIVER == 1
+	Logger->registerLogReceiver(&ConsoleLog, "Console");
+#endif
+#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
+	Logger->registerLogReceiver(FileLog,"File");
+#endif
+      }
+    return Logger;
+  }
+  
+//---------------------------------------------------------------------------------------
+// Audio manager section
+//---------------------------------------------------------------------------------------
 
 #if CAUDIO_COMPILE_WITH_OGG_DECODER == 1
 	static cOggAudioDecoderFactory OggDecoderFactory;
@@ -111,26 +126,6 @@ namespace cAudio
 			manager = NULL;
 		}
 	}
-
-  //////////////////////////////////////////
-
-	CAUDIO_API ILogger* getLogger()
-	{
-        static cLogger* Logger = NULL;
-		if(!Logger)
-		{
-			Logger = new cLogger;
-#if CAUDIO_COMPILE_WITH_CONSOLE_LOG_RECEIVER == 1
-			Logger->registerLogReceiver(&ConsoleLog, "Console");
-#endif
-#if CAUDIO_COMPILE_WITH_FILE_LOG_RECEIVER == 1
-			Logger->registerLogReceiver(FileLog,"File");
-#endif
-		}
-		return Logger;
-	}
-
-
 
 	//---------------------------------------------------------------------------------------
 	// Audio capture section

--- a/cAudio/src/cFileLogReceiver.cpp
+++ b/cAudio/src/cFileLogReceiver.cpp
@@ -10,7 +10,8 @@
 
 namespace cAudio
 {
-	cFileLogReceiver::cFileLogReceiver()
+        cFileLogReceiver::cFileLogReceiver(const char *lFilePath) :
+        logFilePath(lFilePath)
 	{
 		firsttime = false;
 	}
@@ -31,7 +32,7 @@ namespace cAudio
 			// Reset log file
 			outf.setf( std::ios::fixed );
 			outf.precision( 3 );
-			outf.open( "cAudioEngineLog.html", std::ios::out );
+			outf.open( logFilePath, std::ios::out );
 			
 			if( !outf ){
 				return false;
@@ -108,7 +109,7 @@ namespace cAudio
 		}
 		else
 		{
-			outf.open( "cAudioEngineLog.html", std::ios::out | std::ios::app );
+			outf.open( logFilePath, std::ios::out | std::ios::app );
 			
 			if( !outf ){
 				return false;


### PR DESCRIPTION
By default the log file is placed in the current directory, which is fine as default behavior but is very problematic when a more advanced application wants to use cAudio and put it's logs in another place. So I modified the initialization of everything so that the user can now specify where they want the log files to be placed, however the default location is preserved and no interfaces are broken.