### PR TITLE
Also version the .so files of the plugins

### DIFF
--- a/Plugins/EAXLegacyPreset/CMakeLists.txt
+++ b/Plugins/EAXLegacyPreset/CMakeLists.txt
@@ -25,4 +25,7 @@ if(${CAUDIO_STATIC})
 	ADD_DEFINITIONS(-DCAUDIO_STATIC_LIB)
 endif()
 
+set_property(TARGET EAXLegacyPreset PROPERTY VERSION "2.3.0")
+set_property(TARGET EAXLegacyPreset PROPERTY SOVERSION 2 )
+
 install_all_targets(EAXLegacyPreset)

--- a/Plugins/mp3Decoder/CMakeLists.txt
+++ b/Plugins/mp3Decoder/CMakeLists.txt
@@ -25,4 +25,7 @@ if(${CAUDIO_STATIC})
 	ADD_DEFINITIONS(-DCAUDIO_STATIC_LIB)
 endif()
 
+set_property(TARGET cAp_mp3Decoder PROPERTY VERSION "2.3.0")
+set_property(TARGET cAp_mp3Decoder PROPERTY SOVERSION 2 )
+
 install_all_targets(cAp_mp3Decoder)


### PR DESCRIPTION
Use the same versions as current cAudio, for now.

For Fedora, I'll just not build EAXLegacyPreset for now; we can't ship the MP3 decoder plugin anyway for patent/legal reasons. So this isn't a big deal, but it would be nice to get these files fixed too. :)